### PR TITLE
Update Jukebox - Track Queue Size.yaml

### DIFF
--- a/Jukebox - Track Queue Size.yaml
+++ b/Jukebox - Track Queue Size.yaml
@@ -19,10 +19,10 @@ actions:
       items_count: >-
         {% set matches = speaker_data | regex_findall("'items': (\d+)") %} {{
         matches[0] if matches else 0 }}
-        current_index: >-
+      current_index: >-
         {% set matches = speaker_data | regex_findall("'current_index': (\d+)")
         %} {{ matches[0] if matches else 0 }}
-        remaining: "{{ (items_count | int) - (current_index | int) }}"
+      remaining: "{{ (items_count | int) - (current_index | int) }}"
   - action: input_number.set_value
     target:
       entity_id: input_number.jukebox_queue_length


### PR DESCRIPTION
fixed indenting for new variables.

(not actually required, but means it formats properly in github)