### PR TITLE
Fix: Jukebox - Set Default Playlist when Jukebox Queue is Zero

### DIFF
--- a/Jukebox - Set Default Playlist when Jukebox Queue is Zero.yaml
+++ b/Jukebox - Set Default Playlist when Jukebox Queue is Zero.yaml
@@ -4,7 +4,7 @@ triggers:
   - trigger: state
     entity_id:
       - input_number.jukebox_queue_length
-    to: "0.0"
+    to: "1.0"
 conditions: []
 actions:
   - action: input_boolean.turn_off
@@ -12,10 +12,16 @@ actions:
     data: {}
     target:
       entity_id: input_boolean.jukebox_queue
+  - action: media_player.shuffle_set
+    metadata: {}
+    data:
+      shuffle: true
+    target:
+      entity_id: media_player.<YOUR MEDIA PLAYER HERE>
   - action: music_assistant.play_media
     metadata: {}
     data:
-      enqueue: play
+      enqueue: add
       media_id: <YOUR DEFAULT PARTY PLAYLIST HERE>
       media_type: playlist
     target:


### PR DESCRIPTION
**This commit will fix an issue where the default playlist will never start playing after the jukebox queue finishes playback of the last song.**

The issue is that MASS does not remove the last track from the playlist. It just stops playback. This results in the `remaining` variable in the "Jukebox - Track Queue Size" automation never going to 0. It will remain at 1.

The fix involves adding the tracks of the default playlist to the queue when one track remains in the queue. 

I've also added a shuffle action in the automation to avoid the default playlist starting over and over from the top.

Hope this helps! 😀 

- Changed trigger from queue length 0 to 1, since 0 never happens. 
- Added shuffle action to ensure shuffled playback of default playlist, to avoid playing the same songs over and over.
- Changed enqueue from "play" to "add" to add to the queue instead of replacing it.