### PR TITLE
feat: interrupt radio streams

### DIFF
--- a/custom_components/music_assistant_jukebox/files/jukebox.html
+++ b/custom_components/music_assistant_jukebox/files/jukebox.html
@@ -1382,7 +1382,6 @@
 
         async function checkQueueMode() {
             try {
-
                 const response = await fetch(CHECK_QUEUE_MODE_ENDPOINT, {
                     method: 'GET',
                     credentials: "same-origin",
@@ -1398,7 +1397,36 @@
                 }
 
                 const result = await response.json();
-                return result.state === 'on' ? 'add' : 'replace_next';
+                // if queuing, add the song to the end of the queue
+                if (result.state === 'on') {
+                    return 'add';
+                }
+                // check what type of media is playing to decide how to queue the song
+                const queueRequest = {
+                    entity_id: MEDIA_PLAYER
+                };
+
+                const queueResponse = await fetch(GETQUEUE_API_ENDPOINT, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: {
+                        'Authorization': `Bearer ${API_TOKEN}`,
+                        'Content-Type': 'application/json',
+                        'Accept': 'application/json'
+                    },
+                    body: JSON.stringify(queueRequest)
+                });
+                if (queueResponse.ok) {
+                    const qdata = await queueResponse.json();
+                    const queueData = qdata.service_response[MEDIA_PLAYER];
+                    if (queueData && queueData.current_item && queueData.current_item.media_item
+                        && queueData.current_item.media_item.media_type === 'radio') {
+                        // radio streams are infinite length, so play immediately
+                        return 'replace';
+                    }
+                }
+                // default to letting the current track finish before playing selected song
+                return 'replace_next';
 
             } catch (error) {
                 console.error('Error checking queue mode:', error);

--- a/custom_components/music_assistant_jukebox/files/jukebox_controller.yaml
+++ b/custom_components/music_assistant_jukebox/files/jukebox_controller.yaml
@@ -33,7 +33,10 @@ triggers:
     id: Queue Event
   - trigger: state
     entity_id: number.music_assistant_jukebox_jukebox_queue_length
+    from: "1"
     to: "0"
+    for:
+      seconds: 2
     id: Playlist finished
   - trigger: state
     entity_id: switch.music_assistant_jukebox_jukebox_allow_access


### PR DESCRIPTION
Radio streams are infinite length tracks, so queuing requests after them is pointless. If a radio stream is playing when the first song is added to the queue, then interrupt it rather than queuing the selected track up next.

Tighten up the criteria for detecting the end of the playlist, so that "replace" can work without triggering the default playlist. This is required for interrupting radio streams, but it also improves the behaviour in other scenarios when MA is directly controlled to override the default playlist.

- Instead of triggering whenever the queue length goes to 0, require it to go from 1 to 0 This allows "replace" to be used when there is a playlist
- Additionally, require the queue length to remain at 0 for 2 seconds. This gives some time for the newly queued track to start even if the previous playlist was a single track.

This is not perfect. It works well when queuing local tracks, but sometimes tracks from a network provider can take more than 2s to start and get replaced with the default playlist when an internet radio station is the only thing in the playlist when queueing starts.